### PR TITLE
Fix type error in index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,3 +36,5 @@ export type ServerFactory = (
   broker: Aedes,
   options: ServerFactoryOptions
 ) => Server;
+
+export declare const createServer: ServerFactory;


### PR DESCRIPTION
I got this error when I import the package in typescript.

```
Module '"node_modules/aedes-server-factory/types"' has no exported member 'createServer'.
```