### PR TITLE
Update aedes protocol decoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const defaultOptions = {
   extractSocketDetails: extractSocketDetails
 }
 
-const createServer = (aedes, options) => {
+const createServer = (aedes, options = {}) => {
   if (!aedes || !aedes.handle) {
     throw new Error('Missing aedes handler')
   }

--- a/package.json
+++ b/package.json
@@ -64,14 +64,14 @@
     "mqtt-packet": "^6.5.0",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^14.0.2",
+    "release-it": "^14.2.2",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3",
     "tape": "^4.13.0",
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "aedes-protocol-decoder": "^2.0.0",
+    "aedes-protocol-decoder": "^2.0.1",
     "ws": "^7.3.1"
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,7 +34,7 @@ type Server = NetServer | HttpServer | Http2Server | Http2SecureServer;
 
 export type ServerFactory = (
   broker: Aedes,
-  options: ServerFactoryOptions
+  options?: ServerFactoryOptions
 ) => Server;
 
 export declare const createServer: ServerFactory


### PR DESCRIPTION
- Update aedes protocol decoder to avoid issues with import not found
- Quick fix `ServerFactory.options` type to allow passing only one argument to `createServer`