### PR TITLE
change 'error' event for 'websocket-error'

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const createServer = (aedes, options = {}) => {
       }
     }
     const ws = new WebSocket.Server({ server })
-    ws.on('error', error => server.emit('error', error))
+    ws.on('error', error => server.emit('websocket-error', error))
     ws.on('connection', (conn, req) => {
       const stream = WebSocket.createWebSocketStream(conn)
       // the _socket object is needed in bindConnection to retrieve info from the stream


### PR DESCRIPTION
In order to avoid a loop and maximum call stack, i propose we simply change the name or `error`event before injecting it to the server !

to close issue https://github.com/moscajs/aedes-server-factory/issues/7