### PR TITLE
explicit marking dependency on aedes <0.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^14.0.1",
     "@typescript-eslint/eslint-plugin": "^4.28.0",
     "@typescript-eslint/parser": "^4.28.0",
-    "aedes": "^0.46.0",
+    "aedes": "^0.46.0 <0.48.0",
     "faucet": "0.0.1",
     "license-checker": "^25.0.1",
     "mqtt": "^4.2.8",


### PR DESCRIPTION
I don't have the time / knowledge to update the project to work with newer aedes.
But at least in this way the (in-)compatibility is explicitly marked

fixes #19 